### PR TITLE
debian wheezy portmap fix

### DIFF
--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -1,20 +1,13 @@
 class nfs::client::debian inherits nfs::base {
 
-  case $operatingsystem {
-    Debian: {
-      case $lsbdistcodename {
-        squeeze:  {
-          $rpcbind_service_name = "portmap"
-          $rpcbind_package_name = "portmap" 
-        }
-        default:  {
-          $rpcbind_service_name = "rpcbind"
-          $rpcbind_package_name = "rpcbind" 
-        }
-      }
-    default:  {
+  case $lsbdistcodename {
+    squeeze:  {
       $rpcbind_service_name = "portmap"
       $rpcbind_package_name = "portmap" 
+    }
+    default:  {
+      $rpcbind_service_name = "rpcbind"
+      $rpcbind_package_name = "rpcbind" 
     }
   }
   

--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -1,5 +1,21 @@
-class nfs::client::ubuntu inherits nfs::client::debian {
-  Service['nfs-common'] {
-    name => 'statd'
+class nfs::client::ubuntu inherits nfs::base {
+  
+  package { ["nfs-common", "portmap"]:
+    ensure => present,
   }
+ 
+  service { "statd":
+    ensure    => running,
+    enable    => true,
+    hasstatus => true,
+    require   => Package["nfs-common"],
+  }
+ 
+  service { "portmap":
+    ensure    => running,
+    enable    => true,
+    hasstatus => false,
+    require   => Package["portmap"],
+  }
+  
 }


### PR DESCRIPTION
in debian wheezy, it seams to be, that portmap would be removed in the future.
the service is called rpcbind now and the package portmap is only a virtual package which delivers the rpcbind package.
