### PR TITLE
Improved rhel6 detection by using operatingsystemrelease fact.

### DIFF
--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -4,7 +4,7 @@ class nfs::client::redhat inherits nfs::base {
     ensure => present,
   }
 
-  if $lsbmajdistrelease == 6 {
+  if $::operatingsystemrelease =~ /^6.*/ {
 
     package {"rpcbind":
       ensure => present,
@@ -36,16 +36,16 @@ class nfs::client::redhat inherits nfs::base {
     ensure    => running,
     enable    => true,
     hasstatus => true,
-    require   => $lsbmajdistrelease ? {
-      6       => Service["rpcbind"],
+    require   => $::operatingsystemrelease ? {
+      /^6.*/  => Service["rpcbind"],
       default => [Package["portmap"], Package["nfs-utils"]]
     },
   }
  
   service { "netfs":
     enable  => true,
-    require => $lsbmajdistrelease ? {
-      6       => Service["nfslock"],
+    require => $::operatingsystemrelease ? {
+      /^6.*/  => Service["nfslock"],
       default => [Service["portmap"], Service["nfslock"]],
     },
   }


### PR DESCRIPTION
I didn't notice the other pull request related to rhel6 detection before writing this fix. It seems others were not happy with the redhat-lsb dependencies as well.

I'm offering this as an alternative to the other pull request, if desired.
