### PR TITLE
allow to specify the outgoing ip address on mount with "as"

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -3,14 +3,21 @@ define nfs::mount($ensure=present,
                   $share,
                   $mountpoint,
                   $server_options="",
+                  $as="",
                   $client_options="auto") {
+
+  if $as == "" {
+    $guest = $ipaddress
+  } else {
+    $guest = $as
+  }
 
   # use exported ressources
   @@nfs::export {"shared $share by $server for $fqdn":
     ensure          => $ensure,
     share           => $share,
     options         => $server_options,
-    guest           => $ipaddress,
+    guest           => $guest,
     tag             => $server,
   }
 


### PR DESCRIPTION
My servers have multiple IP addresses and the default $ipaddress fact is the wrong one. With this, it can be specified.
