### PR TITLE
ensure nfs-server is running by default

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,7 +4,8 @@
 # Define an NFS server
 #
 class nfs::server(
-  $service_enable = true,
+  $service_enable  = true,
+  $service_running = true,
 ) {
   case $operatingsystem {
     Ubuntu:         { include nfs::server::ubuntu}

--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -15,6 +15,7 @@ class nfs::server::debian inherits nfs::client::debian {
 
   service {"nfs-kernel-server":
     enable  => $nfs::server::service_enable,
+    ensure  => $nfs::server::service_running,
     pattern => "nfsd"
   }
 


### PR DESCRIPTION
This is to make sure puppet starts the nfs service on nfs server.
