### PR TITLE
make Concat[/etc/exports] a virtual resource

### DIFF
--- a/manifests/export.pp
+++ b/manifests/export.pp
@@ -14,6 +14,8 @@ define nfs::export (
     $content = "${share}     ${guest}($options)\n"
   }
 
+  Concat <| title == '/etc/exports' |>
+
   concat::fragment {"${name}-${concatshare}-on-${concatguest}":
     ensure  => $ensure,
     content => $content,

--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -18,7 +18,7 @@ class nfs::server::debian inherits nfs::client::debian {
     pattern => "nfsd"
   }
 
-  concat {'/etc/exports':
+  @concat {'/etc/exports':
     owner  => root,
     group  => root,
     mode   => '0644',


### PR DESCRIPTION
This is fix for error, that occurs when nfs server is created before
clients. Concat fails if fragments dir is empty:

```
/var/lib/puppet/concat/bin/concatfragments.sh -o
/var/lib/puppet/concat/_etc_exports/fragments.concat.out -d
/var/lib/puppet/concat/_etc_exports returned 1 instead of one of [0]
```

Making Concat[/etc/exports] a virtual resource and realizing it in
nfs::export, we make sure that concat is not triggered if there is
nothing to concatenate.
