### PR TITLE
[OI] Incorrect value assigned to $portmap service for Ubuntu 12.04

### DIFF
--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -3,7 +3,7 @@ class nfs::client::debian  {
 
   include ::nfs::params
 
-  package { ['nfs-common', $nfs::params::portmap]:
+  package { ['nfs-common', $nfs::params::portmap::package]:
     ensure => present,
   }
 
@@ -14,11 +14,11 @@ class nfs::client::debian  {
     require   => Package['nfs-common'],
   }
 
-  service {$nfs::params::portmap:
+  service {$nfs::params::portmap::service:
     ensure    => running,
     enable    => true,
     hasstatus => false,
-    require   => Package[$nfs::params::portmap],
+    require   => Package[$nfs::params::portmap::package],
   }
 
 }

--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -3,7 +3,7 @@ class nfs::client::debian  {
 
   include ::nfs::params
 
-  package { ['nfs-common', $nfs::params::portmap::package]:
+  package { ['nfs-common', $nfs::params::portmap_package]:
     ensure => present,
   }
 
@@ -14,11 +14,11 @@ class nfs::client::debian  {
     require   => Package['nfs-common'],
   }
 
-  service {$nfs::params::portmap::service:
+  service {$nfs::params::portmap_service:
     ensure    => running,
     enable    => true,
     hasstatus => false,
-    require   => Package[$nfs::params::portmap::package],
+    require   => Package[$nfs::params::portmap_package],
   }
 
 }

--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -3,5 +3,5 @@ class nfs::client::ubuntu inherits nfs::client::debian {
   Service['nfs-common'] {
     name => 'statd',
   }
-  Package[$nfs::params::portmap::package] { }
+  Package[$nfs::params::portmap_package] { }
 }

--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -3,5 +3,5 @@ class nfs::client::ubuntu inherits nfs::client::debian {
   Service['nfs-common'] {
     name => 'statd',
   }
-  Package[$nfs::params::portmap] { }
+  Package[$nfs::params::portmap::package] { }
 }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -22,7 +22,7 @@ define nfs::mount(
     fstype   => 'nfs',
     name     => $mountpoint,
     options  => $client_options,
-    remounts => false,
+    remounts => true,
     atboot   => true,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # Set default parameters based on distribution release
 class nfs::params {
-  $package::portmap = $::operatingsystem? {
+  $portmap::package = $::operatingsystem? {
     'Debian' => $::lsbdistcodename? {
       'Wheezy' => 'rpcbind',
       default  => 'portmap',
@@ -8,7 +8,7 @@ class nfs::params {
     'Ubuntu' => 'rpcbind',
     default  => 'portmap'
   }
-  $service::portmap = $::operatingsystem? {
+  $portmap::service = $::operatingsystem? {
     'Debian' => $::lsbdistcodename? {
       'Wheezy' => 'rpcbind',
       default  => 'portmap',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,22 @@
 # Set default parameters based on distribution release
 class nfs::params {
-  $portmap = $::operatingsystem? {
+  $package::portmap = $::operatingsystem? {
     'Debian' => $::lsbdistcodename? {
       'Wheezy' => 'rpcbind',
       default  => 'portmap',
     },
     'Ubuntu' => 'rpcbind',
+    default  => 'portmap'
+  }
+  $service::portmap = $::operatingsystem? {
+    'Debian' => $::lsbdistcodename? {
+      'Wheezy' => 'rpcbind',
+      default  => 'portmap',
+    },
+    'Ubuntu' => $::lsbdistcodename? {
+      'trusty' => 'rpcbind',
+      default  => 'portmap',
+    },
     default  => 'portmap'
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # Set default parameters based on distribution release
 class nfs::params {
-  $portmap::package = $::operatingsystem? {
+  $portmap_package = $::operatingsystem? {
     'Debian' => $::lsbdistcodename? {
       'Wheezy' => 'rpcbind',
       default  => 'portmap',
@@ -8,7 +8,7 @@ class nfs::params {
     'Ubuntu' => 'rpcbind',
     default  => 'portmap'
   }
-  $portmap::service = $::operatingsystem? {
+  $portmap_service = $::operatingsystem? {
     'Debian' => $::lsbdistcodename? {
       'Wheezy' => 'rpcbind',
       default  => 'portmap',

--- a/manifests/server/ubuntu.pp
+++ b/manifests/server/ubuntu.pp
@@ -3,5 +3,5 @@ class nfs::server::ubuntu inherits nfs::server::debian {
   Service['nfs-common'] {
     name => 'statd',
   }
-  Package[$nfs::params::portmap] { }
+  Package[$nfs::params::portmap::package] { }
 }

--- a/manifests/server/ubuntu.pp
+++ b/manifests/server/ubuntu.pp
@@ -3,5 +3,5 @@ class nfs::server::ubuntu inherits nfs::server::debian {
   Service['nfs-common'] {
     name => 'statd',
   }
-  Package[$nfs::params::portmap::package] { }
+  Package[$nfs::params::portmap_package] { }
 }


### PR DESCRIPTION
So as to address issue #35, I want to use $portmap_package and $portmap_service variable explicitly for portmap package and service names respectively
