### PR TITLE
Set $nfs::params::portmap to rpcbind on Debian Wheezy and newer.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,8 +2,8 @@
 class nfs::params {
   $portmap = $::operatingsystem? {
     'Debian' => versioncmp($::operatingsystemmajrelease, 7)? {
-      1    => 'rpcbind',
-      0    => 'rpcbind',
+      '1'  => 'rpcbind',
+      '0'  => 'rpcbind',
       '-1' => 'portmap',
     },
     'Ubuntu' => 'rpcbind',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,10 @@
 # Set default parameters based on distribution release
 class nfs::params {
   $portmap = $::operatingsystem? {
-    'Debian' => $::lsbdistcodename? {
-      'Wheezy' => 'rpcbind',
-      default  => 'portmap',
+    'Debian' => versioncmp($::operatingsystemmajrelease, 7)? {
+      1    => 'rpcbind',
+      0    => 'rpcbind',
+      '-1' => 'portmap',
     },
     'Ubuntu' => 'rpcbind',
     default  => 'portmap'


### PR DESCRIPTION
We did that for Wheezy already. Let's do that for anything newer as well.
Without this change, $nfs::params::portmap is erroneously set to 'portmap'
on Debian 8 (Jessie).
