### PR TITLE
Fixed a problem on Ubuntu when calling both server and client classes

### DIFF
--- a/manifests/server/ubuntu.pp
+++ b/manifests/server/ubuntu.pp
@@ -1,7 +1,4 @@
 # Specific settings for server on Ubuntu
 class nfs::server::ubuntu inherits nfs::server::debian {
-  Service['nfs-common'] {
-    name => 'statd',
-  }
   Package[$nfs::params::portmap] { }
 }


### PR DESCRIPTION
I removed an entry that did not seem useful and caused a bug on Ubuntu when both `server` and  `client` classes were called.
