### PR TITLE
Update mount to allow definition of guest IP

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -4,6 +4,7 @@ define nfs::mount(
   $share,
   $mountpoint,
   $ensure         = 'present',
+  $guest          = $::ipaddress,
   $server_options = undef,
   $client_options = 'auto',
 ) {
@@ -13,7 +14,7 @@ define nfs::mount(
     ensure  => $ensure,
     share   => $share,
     options => $server_options,
-    guest   => $::ipaddress,
+    guest   => $guest,
     tag     => $server,
   }
 


### PR DESCRIPTION
I have some servers with multiple IPs, so it's handy to be able to define which IP the client will be connecting from.
