### PR TITLE
Adding support for Oracle Linux

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,7 +6,7 @@ class nfs::client {
   case $::operatingsystem {
     'Ubuntu':            { include ::nfs::client::ubuntu}
     'Debian':            { include ::nfs::client::debian}
-    /^(RedHat|CentOS)$/: { include ::nfs::client::redhat}
+    /^(RedHat|CentOS|OracleLinux)$/: { include ::nfs::client::redhat}
     default:        { notice "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }


### PR DESCRIPTION
Added OracleLinux into the array for redhat basad systems. Maybe using osfamily would work better here?