### PR TITLE
Update concat requirement to enable 2.x version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=1.0.0 <3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Simply bump the required version for concat module. It works almost exactly the same (well, it's a lot less noisy when nothing changes) in my tests (spec & real code)