### PR TITLE
Remove nfs provider for RedHat 7

### DIFF
--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -8,7 +8,6 @@ class nfs::client::redhat inherits nfs::base {
       $nfsclient_service   = 'portmap'
       $nfslock_service     = 'nfslock'
       $netfs_requirement   = [Service['nfs-client'], Service['nfslock']]
-      $provider            = undef
     }
     '6' : {
       $nfslock_requirement = [Service['nfs-client']]
@@ -16,7 +15,6 @@ class nfs::client::redhat inherits nfs::base {
       $nfsclient_service   = 'rpcbind'
       $nfsclient_package   = 'rpcbind'
       $netfs_requirement   = [Service['nfslock']]
-      $provider            = undef
     }
     '7': {
       $nfslock_requirement = [Service['nfs-client']]
@@ -24,7 +22,6 @@ class nfs::client::redhat inherits nfs::base {
       $nfsclient_service   = 'rpcbind'
       $nfsclient_package   = 'rpcbind'
       $netfs_requirement   = undef
-      $provider            = 'redhat'
     }
     default : {
       fail('This Major release is not supported')
@@ -39,7 +36,6 @@ class nfs::client::redhat inherits nfs::base {
   service { 'nfslock':
     ensure    => running,
     name      => $nfslock_service,
-    provider  => $provider,
     enable    => true,
     hasstatus => true,
     require   => $nfslock_requirement,
@@ -58,7 +54,6 @@ class nfs::client::redhat inherits nfs::base {
   service {'nfs-client':
       ensure    => running,
       name      => $nfsclient_service,
-      provider  => $provider,
       enable    => true,
       hasstatus => true,
       require   => $nfsclient_requirement,


### PR DESCRIPTION
This allows redhat 7.6 to NOT use chk-config 
Tested and working as intendend