### PR TITLE
Bump dependency upper limits

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <6.0.0"
+      "version_requirement": ">=4.0.0 <9.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <6.0.0"
+      "version_requirement": ">=1.0.0 <8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <8.0.0"
+      "version_requirement": ">=1.0.0 <10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <9.0.0"
+      "version_requirement": ">=4.0.0 <10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Bumps concat and stdlib upper version constraints to permit latest version of each.

Changes tested locally on Alma Linux 8