### PR TITLE
Adjust service names to support Debian 11 and newer

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,15 +10,15 @@ class nfs::params {
           $portmap_package = 'portmap'
           $statd_service   = 'nfs-common'
         }
-        'stretch', 'buster': {
+        'wheezy', 'jessie': {
           $portmap_service = 'rpcbind'
           $portmap_package = 'rpcbind'
-          $statd_service   = 'rpc-statd'
+          $statd_service   = 'nfs-common'
         }
         default: {
           $portmap_service = 'rpcbind'
           $portmap_package = 'rpcbind'
-          $statd_service   = 'nfs-common'
+          $statd_service   = 'rpc-statd'
         }
       }
       $portmap_enable = true


### PR DESCRIPTION
Previously the "default" clause was meant for Wheezy (released in 2013) and
Jessie (released in 2015), and we had to explicitly add support for
anything newer.

This commit turns this logic around:

 - Releases which are EOL'ed since 10+ years are not supported anymore.
 - Older releases that are either still somewhat supported (Jessie)
   or that are EOL since less than 5 years (Squeeze, Wheezy)
   are still supported, but treated as exceptions.
 - Newer releases (starting with Stretch, released in 2017) are the default.
 - Future Debian releases will automatically use the same modern params
   as Stretch, Buster, and Bullseye. This will avoid the need to go through
   the updating process every 2 years (#59, then this very PR).