### PR TITLE
set `ensure => installed` for packages instead of `present`

### DIFF
--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -4,7 +4,7 @@ class nfs::client::debian  {
   include ::nfs::params
 
   package { ['nfs-common', $nfs::params::portmap_package]:
-    ensure => present,
+    ensure => installed,
   }
 
   service {$::nfs::params::statd_service:

--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -37,7 +37,7 @@ class nfs::client::redhat inherits nfs::base {
   # common items for all versions
   $nfsclient_requirement  = [Package['nfs-client'], Package['nfs-utils']]
   package { 'nfs-utils':
-    ensure => present,
+    ensure => installed,
   }
 
   service { 'nfslock':
@@ -54,7 +54,7 @@ class nfs::client::redhat inherits nfs::base {
     }
   }
   package { 'nfs-client':
-    ensure => present,
+    ensure => installed,
     name   => $nfsclient_package,
   }
 

--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -2,7 +2,7 @@
 class nfs::server::debian inherits nfs::client::debian {
 
   package {'nfs-kernel-server':
-    ensure => present,
+    ensure => installed,
   }
 
   exec {'reload_nfs_srv':


### PR DESCRIPTION
This allows for compatibility with stdlib v8 due to https://github.com/puppetlabs/puppetlabs-stdlib/pull/1196.