### PR TITLE
Update legacy facts; drop code for EOL OSes

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -3,10 +3,10 @@
 # This class configures NFS on client side
 #
 class nfs::client {
-  case $::osfamily {
-    'Debian': { include ::nfs::client::debian}
-    'RedHat': { include ::nfs::client::redhat}
-    default: { notice "Unsupported operatingsystem ${::operatingsystem}" }
+  case $facts['os']['family'] {
+    'Debian': { include nfs::client::debian }
+    'RedHat': { include nfs::client::redhat }
+    default: { notice "Unsupported operating system ${facts['os']['family']}" }
   }
 }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,4 +9,3 @@ class nfs::client {
     default: { notice "Unsupported operating system ${facts['os']['family']}" }
   }
 }
-

--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -1,24 +1,27 @@
 # Specific settings for client on Debian distribution.
-class nfs::client::debian  {
+class nfs::client::debian {
+  include nfs::params
 
-  include ::nfs::params
-
-  package { ['nfs-common', $nfs::params::portmap_package]:
-    ensure => present,
+  [
+    'nfs-common',
+    $nfs::params::portmap_package,
+  ].each |String[1] $pkg| {
+    package { $pkg:
+      ensure => installed,
+    }
   }
 
-  service {$::nfs::params::statd_service:
+  service { $nfs::params::statd_service:
     ensure    => running,
     enable    => true,
     hasstatus => true,
     require   => Package['nfs-common'],
   }
 
-  service {$::nfs::params::portmap_service:
+  service { $nfs::params::portmap_service:
     ensure    => running,
-    enable    => $::nfs::params::portmap_enable,
+    enable    => $nfs::params::portmap_enable,
     hasstatus => false,
     require   => Package[$nfs::params::portmap_package],
   }
-
 }

--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -8,12 +8,12 @@ class nfs::client::redhat inherits nfs::base {
       $nfsclient_package   = 'rpcbind'
       $netfs_requirement   = undef
     }
-    default : {
+
+    default: {
       fail('This Major release is not supported')
     }
   }
-  # common items for all versions
-  $nfsclient_requirement  = [Package['nfs-client'], Package['nfs-utils']]
+
   package { 'nfs-utils':
     ensure => present,
   }
@@ -25,24 +25,22 @@ class nfs::client::redhat inherits nfs::base {
     hasstatus => true,
     require   => $nfslock_requirement,
   }
-  if  versioncmp($::operatingsystemmajrelease, '7')  < 0 {
-    service { 'netfs':
-      enable  => true,
-      require => $netfs_requirement,
-    }
-  }
+
   package { 'nfs-client':
     ensure => present,
     name   => $nfsclient_package,
   }
 
   if $nfsclient_service {
-    service {'nfs-client':
+    service { 'nfs-client':
       ensure    => running,
       name      => $nfsclient_service,
       enable    => true,
       hasstatus => true,
-      require   => $nfsclient_requirement,
+      require   => [
+        Package['nfs-client'],
+        Package['nfs-utils'],
+      ],
     }
   }
 }

--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -1,28 +1,6 @@
 # Specific settings for client on Redhat distribution.
 class nfs::client::redhat inherits nfs::base {
-
-  case  $::operatingsystemmajrelease {
-    '5' : {
-      $nfslock_requirement = [Package['nfs-client'], Package['nfs-utils']]
-      $nfsclient_package   = 'portmap'
-      $nfsclient_service   = 'portmap'
-      $nfslock_service     = 'nfslock'
-      $netfs_requirement   = [Service['nfs-client'], Service['nfslock']]
-    }
-    '6' : {
-      $nfslock_requirement = [Service['nfs-client']]
-      $nfslock_service     = 'nfslock'
-      $nfsclient_service   = 'rpcbind'
-      $nfsclient_package   = 'rpcbind'
-      $netfs_requirement   = [Service['nfslock']]
-    }
-    '7': {
-      $nfslock_requirement = undef
-      $nfslock_service     = 'rpc-statd'
-      $nfsclient_service   = undef
-      $nfsclient_package   = 'rpcbind'
-      $netfs_requirement   = undef
-    }
+  case $facts['os']['release']['major'] {
     '8': {
       $nfslock_requirement = undef
       $nfslock_service     = 'rpc-statd'

--- a/manifests/export.pp
+++ b/manifests/export.pp
@@ -5,7 +5,6 @@ define nfs::export (
   $ensure  = 'present',
   $options = undef,
 ) {
-
   $concatshare = regsubst($share, '/', '-', 'G')
   $concatguest = regsubst($guest, '/','-', 'G')
 
@@ -17,10 +16,9 @@ define nfs::export (
 
   Concat <| title == '/etc/exports' |>
   if $ensure == 'present' {
-    concat::fragment {"${name}-${concatshare}-on-${concatguest}":
+    concat::fragment { "${name}-${concatshare}-on-${concatguest}":
       content => $content,
       target  => '/etc/exports',
     }
   }
-
 }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -4,13 +4,13 @@ define nfs::mount(
   $share,
   $mountpoint,
   $ensure         = 'present',
-  $guest          = $::ipaddress,
+  $guest          = $facts['networking']['ip'],
   $server_options = undef,
   $client_options = 'auto',
 ) {
 
   # use exported resources
-  @@nfs::export {"shared ${share} by ${server} for ${::fqdn} mounted on ${mountpoint}":
+  @@nfs::export { "shared ${share} by ${server} for ${facts['networking']['fqdn']} mounted on ${mountpoint}":
     ensure  => $ensure,
     share   => $share,
     options => $server_options,
@@ -32,7 +32,7 @@ define nfs::mount(
       exec {"create ${mountpoint} and parents":
         command => "mkdir -p ${mountpoint}",
         unless  => "test -d ${mountpoint}",
-        path    => $::path,
+        path    => $facts['path'],
       }
       Mount["shared ${share} by ${server} mounted on ${mountpoint}"] {
         require => [Exec["create ${mountpoint} and parents"], Class['nfs::client']],

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -1,5 +1,5 @@
 # This defines an NFS mount point
-define nfs::mount(
+define nfs::mount (
   $server,
   $share,
   $mountpoint,
@@ -8,7 +8,6 @@ define nfs::mount(
   $server_options = undef,
   $client_options = 'auto',
 ) {
-
   # use exported resources
   @@nfs::export { "shared ${share} by ${server} for ${facts['networking']['fqdn']} mounted on ${mountpoint}":
     ensure  => $ensure,
@@ -18,7 +17,7 @@ define nfs::mount(
     tag     => $server,
   }
 
-  mount {"shared ${share} by ${server} mounted on ${mountpoint}":
+  mount { "shared ${share} by ${server} mounted on ${mountpoint}":
     device   => "${server}:${share}",
     fstype   => 'nfs',
     name     => $mountpoint,
@@ -29,7 +28,7 @@ define nfs::mount(
 
   case $ensure {
     'present': {
-      exec {"create ${mountpoint} and parents":
+      exec { "create ${mountpoint} and parents":
         command => "mkdir -p ${mountpoint}",
         unless  => "test -d ${mountpoint}",
         path    => $facts['path'],
@@ -54,5 +53,4 @@ define nfs::mount(
       fail('Ensure should be `present` or `absent`')
     }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,40 +2,21 @@
 class nfs::params {
 
   # These params only used by the nfs::client::debian class
-  case $::operatingsystem {
+  case $facts['os']['name'] {
     'Debian': {
-      case $::lsbdistcodename {
-        'squeeze': {
-          $portmap_service = 'portmap'
-          $portmap_package = 'portmap'
-          $statd_service   = 'nfs-common'
-        }
-        'stretch', 'buster': {
-          $portmap_service = 'rpcbind'
-          $portmap_package = 'rpcbind'
-          $statd_service   = 'rpc-statd'
-        }
-        default: {
-          $portmap_service = 'rpcbind'
-          $portmap_package = 'rpcbind'
-          $statd_service   = 'nfs-common'
-        }
-      }
+      $portmap_service = 'rpcbind'
+      $portmap_package = 'rpcbind'
+      $statd_service   = 'rpc-statd'
       $portmap_enable = true
     }
     'Ubuntu': {
       $portmap_service = 'rpcbind'
       $portmap_package = 'rpcbind'
-      if versioncmp($::operatingsystemrelease, '16.04') >= 0 {
-        $portmap_enable = undef
-        $statd_service = 'rpc-statd'
-      } else {
-        $portmap_enable = true
-        $statd_service = 'statd'
-      }
+      $portmap_enable = undef
+      $statd_service = 'rpc-statd'
     }
     default: {
-      fail("Operating system not supported ${::operatingsystem}")
+      fail("Operating system not supported ${facts['os']['family']}")
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,5 @@
 # Set default parameters based on distribution release
 class nfs::params {
-
   # These params only used by the nfs::client::debian class
   case $facts['os']['name'] {
     'Debian': {
@@ -9,12 +8,14 @@ class nfs::params {
       $statd_service   = 'rpc-statd'
       $portmap_enable = true
     }
+
     'Ubuntu': {
       $portmap_service = 'rpcbind'
       $portmap_package = 'rpcbind'
       $portmap_enable = undef
       $statd_service = 'rpc-statd'
     }
+
     default: {
       fail("Operating system not supported ${facts['os']['family']}")
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,9 +7,9 @@ class nfs::server(
   $service_enable  = true,
   $service_running = true,
 ) {
-  case $::osfamily {
-    'Debian': { include ::nfs::server::debian}
-    'RedHat': { include ::nfs::server::redhat }
-    default: { notice "Unsupported operatingsystem ${::operatingsystem}" }
+  case $facts['os']['family'] {
+    'Debian': { include nfs::server::debian }
+    'RedHat': { include nfs::server::redhat }
+    default: { notice "Unsupported operating system ${facts['os']['family']}" }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,7 +3,7 @@
 #
 # Define an NFS server
 #
-class nfs::server(
+class nfs::server (
   $service_enable  = true,
   $service_running = true,
 ) {

--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -1,28 +1,26 @@
 # Specific settings for server on Debian
 class nfs::server::debian inherits nfs::client::debian {
-
-  package {'nfs-kernel-server':
+  package { 'nfs-kernel-server':
     ensure => present,
   }
 
-  exec {'reload_nfs_srv':
+  exec { 'reload_nfs_srv':
     command     => '/etc/init.d/nfs-kernel-server reload',
     onlyif      => '/etc/init.d/nfs-kernel-server status',
     refreshonly => true,
     require     => Package['nfs-kernel-server'],
   }
 
-  service {'nfs-kernel-server':
+  service { 'nfs-kernel-server':
     ensure  => $nfs::server::service_running,
     enable  => $nfs::server::service_enable,
     pattern => 'nfsd',
   }
 
-  @concat {'/etc/exports':
+  @concat { '/etc/exports':
     owner  => root,
     group  => root,
     mode   => '0644',
     notify => Exec['reload_nfs_srv'],
   }
-
 }

--- a/manifests/server/redhat.pp
+++ b/manifests/server/redhat.pp
@@ -5,14 +5,7 @@
 # TODO: add NFS v4 support
 #
 class nfs::server::redhat inherits nfs::client::redhat {
-
-  if Integer($::operatingsystemmajrelease) >= 7 {
-    $servicename = 'nfs-server'
-  } else {
-    $servicename = 'nfs'
-  }
-
-  service{ 'nfs':
+  service { 'nfs':
     ensure    => running,
     name      => $servicename,
     enable    => true,

--- a/manifests/server/redhat.pp
+++ b/manifests/server/redhat.pp
@@ -7,17 +7,16 @@
 class nfs::server::redhat inherits nfs::client::redhat {
   service { 'nfs':
     ensure    => running,
-    name      => $servicename,
+    name      => 'nfs-server',
     enable    => true,
     hasstatus => true,
-    require   => Package[ 'nfs-utils' ],
+    require   => Package['nfs-utils'],
   }
 
-  @concat {'/etc/exports':
+  @concat { '/etc/exports':
     owner  => root,
     group  => root,
     mode   => '0644',
     notify => Service['nfs'],
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,64 +10,40 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <6.0.0"
+      "version_requirement": ">= 1.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <6.0.0"
+      "version_requirement": ">= 4.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04"
+        "20.04",
+        "22.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
-        "7",
         "8"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 9.0.0"
     }
-  ],
-  "puppet_version": [
-    "2.7",
-    "3.0",
-    "3.1",
-    "3.2",
-    "3.3",
-    "3.4",
-    "3.5",
-    "3.6",
-    "3.7"
   ],
   "pdk-version": "1.15.0",
   "template-url": "pdk-default#1.15.0",


### PR DESCRIPTION
I'm only using this on Ubuntu, so I can't say whether this is correct on other OSes. Just putting this here in case it's useful to someone else. This module is unmaintained since 2020, so I'm likely switching to https://github.com/voxpupuli/puppet-nfs.